### PR TITLE
Fixed IE error when using domElement.currentStyle as a function instead of object

### DIFF
--- a/sol.js
+++ b/sol.js
@@ -328,7 +328,7 @@
             $element.css('display', 'none');
 
             if (domElement.currentStyle) {
-                return domElement.currentStyle(property);
+                return domElement.currentStyle[property];
             } else if (window.getComputedStyle) {
                 return document.defaultView.getComputedStyle(domElement, null).getPropertyValue(property);
             }


### PR DESCRIPTION
domElement.currentStyle is an object, so calling it as a function caused "function expected" exception on IE