### PR TITLE
fixing label click

### DIFF
--- a/sol.css
+++ b/sol.css
@@ -213,11 +213,11 @@
 }
 
 .sol-option {
-    padding: 5px 10px;
     display: block;
 }
 
 .sol-label {
+    padding: 5px 10px;
     display: block;
     position: relative;
 }


### PR DESCRIPTION
Clicking on the label behaves like the click on the checkbox/radio input. However the label was slightly smaller than the whole option so there was a little not-clickable area (observable near the delimiter line). This fixes the problem.